### PR TITLE
fix(vault): Backticks db name in case of special chars

### DIFF
--- a/vault.tf
+++ b/vault.tf
@@ -15,7 +15,7 @@ resource "vault_database_secret_backend_role" "this" {
   creation_statements = concat(
     [
       "CREATE USER '{{name}}'@'%' IDENTIFIED BY '{{password}}';",
-      "GRANT ${each.value} ON ${var.database}.* TO '{{name}}'@'%';",
+      "GRANT ${each.value} ON `${var.database}`.* TO '{{name}}'@'%';",
     ], coalesce(var.vault_roles_extra_statements[each.key], []),
   )
 


### PR DESCRIPTION
e.g.: Currently, the role will fail if the database name contains a dash

cc @albertollamaso 